### PR TITLE
Add build step for single-file deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ignore.png
 dev/*
-dev
+dist/
+
+node_modules/

--- a/build.js
+++ b/build.js
@@ -1,0 +1,20 @@
+import { build } from 'esbuild';
+import { readFileSync } from 'fs';
+
+const glslPlugin = {
+  name: 'glsl',
+  setup(build) {
+    build.onLoad({ filter: /\.glsl$/ }, args => ({
+      contents: JSON.stringify(readFileSync(args.path, 'utf8')),
+      loader: 'text'
+    }));
+  }
+};
+
+build({
+  entryPoints: ['javascript/main.js'],
+  bundle: true,
+  minify: true,
+  plugins: [glslPlugin],
+  outfile: 'dist/bundle.min.js',
+}).catch(() => process.exit(1));

--- a/build.js
+++ b/build.js
@@ -5,7 +5,7 @@ const glslPlugin = {
   name: 'glsl',
   setup(build) {
     build.onLoad({ filter: /\.glsl$/ }, args => ({
-      contents: JSON.stringify(readFileSync(args.path, 'utf8')),
+      contents: readFileSync(args.path, 'utf8'),
       loader: 'text'
     }));
   }

--- a/dev.js
+++ b/dev.js
@@ -1,0 +1,25 @@
+import { context } from 'esbuild';
+import { readFileSync } from 'fs';
+
+const glslPlugin = {
+  name: 'glsl',
+  setup(build) {
+    build.onLoad({ filter: /\.glsl$/ }, args => ({
+      contents: JSON.stringify(readFileSync(args.path, 'utf8')),
+      loader: 'text'
+    }));
+  }
+};
+
+const ctx = await context({
+  entryPoints: ['javascript/main.js'],
+  bundle: true,
+  sourcemap: true,
+  plugins: [glslPlugin],
+  outfile: 'dist/bundle.js'
+});
+
+await ctx.watch();
+const { host, port } = await ctx.serve({ servedir: '.', port: 8080 });
+console.log(`Dev server running at http://${host}:${port}`);
+

--- a/dev.js
+++ b/dev.js
@@ -5,7 +5,7 @@ const glslPlugin = {
   name: 'glsl',
   setup(build) {
     build.onLoad({ filter: /\.glsl$/ }, args => ({
-      contents: JSON.stringify(readFileSync(args.path, 'utf8')),
+      contents: readFileSync(args.path, 'utf8'),
       loader: 'text'
     }));
   }

--- a/index.html
+++ b/index.html
@@ -34,5 +34,7 @@
 </head>
 <body>
   <script type="module" src="./javascript/main.js"></script>
+  <!-- Use the line below after running the build script -->
+  <!-- <script src="./dist/bundle.min.js"></script> -->
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,8 +33,9 @@
   </style>
 </head>
 <body>
-  <script type="module" src="./javascript/main.js"></script>
-  <!-- Use the line below after running the build script -->
+  <!-- Development bundle served by `npm run dev` -->
+  <script src="./dist/bundle.js"></script>
+  <!-- Use the line below after running the production build -->
   <!-- <script src="./dist/bundle.min.js"></script> -->
 </body>
 </html>

--- a/javascript/runShaderOnCanvas.js
+++ b/javascript/runShaderOnCanvas.js
@@ -1,4 +1,6 @@
 import {
+  vertexSource,
+  fragmentSource,
   loadShaderSource
 } from "./shaders.js";
 
@@ -16,10 +18,11 @@ export async function runShaderOnCanvas(canvasName) {
   const gl = canvas.getContext('webgl2');
   if (!gl) { alert('WebGL2 required'); return; }
 
-  // compile and link the program
-  const vertexSource = await loadShaderSource('../shaders/vertex.glsl');
-  const fragmentSource = await loadShaderSource('../shaders/fragment.glsl');
-  const prog = createProgram(gl, vertexSource, fragmentSource);
+  // compile and link the program. When bundled, vertexSource and
+  // fragmentSource are inlined; otherwise fall back to fetching them.
+  const vsSrc = vertexSource || await loadShaderSource('../shaders/vertex.glsl');
+  const fsSrc = fragmentSource || await loadShaderSource('../shaders/fragment.glsl');
+  const prog = createProgram(gl, vsSrc, fsSrc);
   gl.useProgram(prog);
 
   // general attributed and locations

--- a/javascript/shaders.js
+++ b/javascript/shaders.js
@@ -1,7 +1,12 @@
 // ----- Shader Sources -----
-export const vertexSource = `MOVED TO SHADERS FILE`;
+// When bundled with `npm run build` the GLSL files are inlined so these
+// imports resolve to the shader source strings. During development the
+// variables will be `undefined` and the shaders will instead be fetched
+// over the network by `loadShaderSource()`.
+import vertexSource from "../shaders/vertex.glsl";
+import fragmentSource from "../shaders/fragment.glsl";
 
-export const fragmentSource = `MOVED TO SHADERS FILE`;
+export { vertexSource, fragmentSource };
 
 export async function loadShaderSource(path) {
   const res = await fetch(path);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,427 @@
+{
+  "name": "webgl-noisy-gradients",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "webgl-noisy-gradients",
+      "version": "1.0.0",
+      "devDependencies": {
+        "esbuild": "^0.18.0"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
+      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/android-arm": "0.18.20",
+        "@esbuild/android-arm64": "0.18.20",
+        "@esbuild/android-x64": "0.18.20",
+        "@esbuild/darwin-arm64": "0.18.20",
+        "@esbuild/darwin-x64": "0.18.20",
+        "@esbuild/freebsd-arm64": "0.18.20",
+        "@esbuild/freebsd-x64": "0.18.20",
+        "@esbuild/linux-arm": "0.18.20",
+        "@esbuild/linux-arm64": "0.18.20",
+        "@esbuild/linux-ia32": "0.18.20",
+        "@esbuild/linux-loong64": "0.18.20",
+        "@esbuild/linux-mips64el": "0.18.20",
+        "@esbuild/linux-ppc64": "0.18.20",
+        "@esbuild/linux-riscv64": "0.18.20",
+        "@esbuild/linux-s390x": "0.18.20",
+        "@esbuild/linux-x64": "0.18.20",
+        "@esbuild/netbsd-x64": "0.18.20",
+        "@esbuild/openbsd-x64": "0.18.20",
+        "@esbuild/sunos-x64": "0.18.20",
+        "@esbuild/win32-arm64": "0.18.20",
+        "@esbuild/win32-ia32": "0.18.20",
+        "@esbuild/win32-x64": "0.18.20"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "node build.js",
-    "dev": "node dev.js"
+    "dev": "node dev.js",
+    "test": "node test-dev.js"
   },
   "devDependencies": {
     "esbuild": "^0.18.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "webgl-noisy-gradients",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "build": "node build.js"
+  },
+  "devDependencies": {
+    "esbuild": "^0.18.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "type": "module",
   "scripts": {
-    "build": "node build.js"
+    "build": "node build.js",
+    "dev": "node dev.js"
   },
   "devDependencies": {
     "esbuild": "^0.18.0"

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,18 @@ A beautiful, fully configurable, WebGL-powered “spray-paint” gradient system
 3. Run `python -m http.server 8080` 🏃
 4. Visit `localhost:8080` in your web browser 🎉
 
+### Building a Minified Bundle
+
+If you want to deploy a single minified script including the shader sources run:
+
+```bash
+npm install
+npm run build
+```
+
+The output `dist/bundle.min.js` contains the entire application and can be
+included in your HTML instead of the individual modules.
+
 You can then have a look at `gradients.js` and reconfigure the blobs as you like. Currently page height you can scroll is set using the height CSS property in `index.html`.
 
 ## Configuration

--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,7 @@ A beautiful, fully configurable, WebGL-powered “spray-paint” gradient system
 3. Run `npm install`
 4. Run `npm run dev` to start the dev server 🏃
 5. Visit `localhost:8080` in your web browser 🎉
+6. Run `npm test` to verify the dev bundle loads correctly
 
 ### Building a Minified Bundle
 

--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,9 @@ A beautiful, fully configurable, WebGL-powered “spray-paint” gradient system
 
 1. Clone this repo 👥
 2. Navigate to the repo directory with your shell 🐚
-3. Run `python -m http.server 8080` 🏃
-4. Visit `localhost:8080` in your web browser 🎉
+3. Run `npm install`
+4. Run `npm run dev` to start the dev server 🏃
+5. Visit `localhost:8080` in your web browser 🎉
 
 ### Building a Minified Bundle
 
@@ -21,7 +22,8 @@ npm run build
 ```
 
 The output `dist/bundle.min.js` contains the entire application and can be
-included in your HTML instead of the individual modules.
+included in your HTML instead of the individual modules. During development,
+`npm run dev` serves an unminified `dist/bundle.js` that rebuilds on changes.
 
 You can then have a look at `gradients.js` and reconfigure the blobs as you like. Currently page height you can scroll is set using the height CSS property in `index.html`.
 

--- a/test-dev.js
+++ b/test-dev.js
@@ -1,0 +1,43 @@
+import { spawn } from 'child_process';
+import { request } from 'http';
+
+function fetchText(url) {
+  return new Promise((resolve, reject) => {
+    const req = request(url, res => {
+      let data = '';
+      res.setEncoding('utf8');
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => resolve(data));
+    });
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+async function main() {
+  const proc = spawn('node', ['dev.js']);
+  proc.stdout.setEncoding('utf8');
+  await new Promise((resolve, reject) => {
+    proc.stdout.on('data', d => {
+      process.stdout.write(d);
+      if (d.includes('Dev server running')) resolve();
+    });
+    proc.on('error', reject);
+  });
+
+  const html = await fetchText('http://localhost:8080/index.html');
+  const js = await fetchText('http://localhost:8080/dist/bundle.js');
+
+  try {
+    new Function(js);
+    console.log('Bundle parsed successfully');
+  } catch (e) {
+    console.error('JS parse error', e);
+    process.exitCode = 1;
+  }
+
+  proc.kill();
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- add build.js with esbuild to bundle and minify sources
- inline shader sources for bundling
- update runShaderOnCanvas to use inlined shaders when available
- include npm configuration and instructions
- document bundle usage and reference in index.html
- ignore build and node_modules directories

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a243b9b5883229db3846dc4dbb29c